### PR TITLE
Update Scoring Methodology to Integrate Stack Layers

### DIFF
--- a/cmd/calculator/res/config-mqtt-opa.json
+++ b/cmd/calculator/res/config-mqtt-opa.json
@@ -26,6 +26,11 @@
           "collectionName": "scoring",
           "from": ["scores"],
           "to": ["data"]
+        },
+        {
+          "collectionName": "linkage",
+          "from": ["scores"],
+          "to": ["scores"]
         }
       ],
       "graphName": "example-graph",

--- a/cmd/calculator/res/config-mqtt-opa.json
+++ b/cmd/calculator/res/config-mqtt-opa.json
@@ -28,7 +28,7 @@
           "to": ["data"]
         },
         {
-          "collectionName": "linkage",
+          "collectionName": "stack",
           "from": ["scores"],
           "to": ["scores"]
         }

--- a/cmd/calculator/res/config-mqtt.json
+++ b/cmd/calculator/res/config-mqtt.json
@@ -26,6 +26,11 @@
           "collectionName": "scoring",
           "from": ["scores"],
           "to": ["data"]
+        },
+        {
+          "collectionName": "linkage",
+          "from": ["scores"],
+          "to": ["scores"]
         }
       ],
       "graphName": "example-graph",

--- a/cmd/calculator/res/config-mqtt.json
+++ b/cmd/calculator/res/config-mqtt.json
@@ -28,7 +28,7 @@
           "to": ["data"]
         },
         {
-          "collectionName": "linkage",
+          "collectionName": "stack",
           "from": ["scores"],
           "to": ["scores"]
         }

--- a/cmd/calculator/res/docker/config-mqtt-opa.json
+++ b/cmd/calculator/res/docker/config-mqtt-opa.json
@@ -26,6 +26,11 @@
           "collectionName": "scoring",
           "from": ["scores"],
           "to": ["data"]
+        },
+        {
+          "collectionName": "linkage",
+          "from": ["scores"],
+          "to": ["scores"]
         }
       ],
       "graphName": "example-graph",

--- a/cmd/calculator/res/docker/config-mqtt-opa.json
+++ b/cmd/calculator/res/docker/config-mqtt-opa.json
@@ -28,7 +28,7 @@
           "to": ["data"]
         },
         {
-          "collectionName": "linkage",
+          "collectionName": "stack",
           "from": ["scores"],
           "to": ["scores"]
         }

--- a/cmd/calculator/res/docker/config-mqtt.json
+++ b/cmd/calculator/res/docker/config-mqtt.json
@@ -26,6 +26,11 @@
           "collectionName": "scoring",
           "from": ["scores"],
           "to": ["data"]
+        },
+        {
+          "collectionName": "linkage",
+          "from": ["scores"],
+          "to": ["scores"]
         }
       ],
       "graphName": "example-graph",

--- a/cmd/calculator/res/docker/config-mqtt.json
+++ b/cmd/calculator/res/docker/config-mqtt.json
@@ -28,7 +28,7 @@
           "to": ["data"]
         },
         {
-          "collectionName": "linkage",
+          "collectionName": "stack",
           "from": ["scores"],
           "to": ["scores"]
         }

--- a/cmd/subscriber/res/config-mqtt.json
+++ b/cmd/subscriber/res/config-mqtt.json
@@ -56,7 +56,7 @@
           "to": ["data"]
         },
         {
-          "collectionName": "linkage",
+          "collectionName": "stack",
           "from": ["scores"],
           "to": ["scores"]
         }

--- a/cmd/subscriber/res/config-mqtt.json
+++ b/cmd/subscriber/res/config-mqtt.json
@@ -54,6 +54,11 @@
           "collectionName": "scoring",
           "from": ["scores"],
           "to": ["data"]
+        },
+        {
+          "collectionName": "linkage",
+          "from": ["scores"],
+          "to": ["scores"]
         }
       ],
       "graphName": "example-graph",

--- a/cmd/subscriber/res/config.json
+++ b/cmd/subscriber/res/config.json
@@ -36,6 +36,11 @@
           "collectionName": "scoring",
           "from": ["scores"],
           "to": ["data"]
+        },
+        {
+          "collectionName": "linkage",
+          "from": ["scores"],
+          "to": ["scores"]
         }
       ],
       "graphName": "example-graph",

--- a/cmd/subscriber/res/config.json
+++ b/cmd/subscriber/res/config.json
@@ -38,7 +38,7 @@
           "to": ["data"]
         },
         {
-          "collectionName": "linkage",
+          "collectionName": "stack",
           "from": ["scores"],
           "to": ["scores"]
         }

--- a/cmd/subscriber/res/docker/config-mqtt.json
+++ b/cmd/subscriber/res/docker/config-mqtt.json
@@ -56,7 +56,7 @@
           "to": ["data"]
         },
         {
-          "collectionName": "linkage",
+          "collectionName": "stack",
           "from": ["scores"],
           "to": ["scores"]
         }

--- a/cmd/subscriber/res/docker/config-mqtt.json
+++ b/cmd/subscriber/res/docker/config-mqtt.json
@@ -54,6 +54,11 @@
           "collectionName": "scoring",
           "from": ["scores"],
           "to": ["data"]
+        },
+        {
+          "collectionName": "linkage",
+          "from": ["scores"],
+          "to": ["scores"]
         }
       ],
       "graphName": "example-graph",

--- a/cmd/subscriber/res/docker/config.json
+++ b/cmd/subscriber/res/docker/config.json
@@ -36,6 +36,11 @@
           "collectionName": "scoring",
           "from": ["scores"],
           "to": ["data"]
+        },
+        {
+          "collectionName": "linkage",
+          "from": ["scores"],
+          "to": ["scores"]
         }
       ],
       "graphName": "example-graph",

--- a/cmd/subscriber/res/docker/config.json
+++ b/cmd/subscriber/res/docker/config.json
@@ -38,7 +38,7 @@
           "to": ["data"]
         },
         {
-          "collectionName": "linkage",
+          "collectionName": "stack",
           "from": ["scores"],
           "to": ["scores"]
         }

--- a/internal/calculator/calculator.go
+++ b/internal/calculator/calculator.go
@@ -163,7 +163,7 @@ func (c *Calculator) score(ctx context.Context, key string) {
 
 		for _, tagScore := range tagScoreMap {
 			// Create an edge between the app score and CICD score
-			err = c.dbClient.CreateEdge(ctx, tagScore.Key.String(), docScore.Key.String(), documents.EdgeLinkage)
+			err = c.dbClient.CreateEdge(ctx, tagScore.Key.String(), docScore.Key.String(), documents.EdgeStack)
 			if err != nil {
 				c.logger.Error(err.Error())
 				return

--- a/internal/calculator/calculator.go
+++ b/internal/calculator/calculator.go
@@ -12,168 +12,177 @@
  * the License.
  *******************************************************************************/
 
- package calculator
+package calculator
 
- import (
-	 "context"
-	 "fmt"
-	 "log/slog"
- 
-	 "sync"
-	 "time"
- 
-	 "github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
-	 "github.com/project-alvarium/alvarium-sdk-go/pkg/interfaces"
-	 "github.com/project-alvarium/scoring-apps-go/internal/calculator/types"
-	 "github.com/project-alvarium/scoring-apps-go/internal/config"
-	 "github.com/project-alvarium/scoring-apps-go/pkg/documents"
-	 "github.com/project-alvarium/scoring-apps-go/pkg/policies"
- )
- 
- type Calculator struct {
-	 chKeys    chan string
-	 condition *sync.Cond
-	 dbClient  *ArangoClient
-	 dbConfig  config.DatabaseInfo
-	 logger    interfaces.Logger
-	 workQueue *types.WorkQueue
-	 policy    policies.DcfPolicy
- }
- 
- const (
-	 workerMax int = 5
- )
- 
- func NewCalculator(chKeys chan string, dbConfig config.DatabaseInfo, logger interfaces.Logger, policy policies.DcfPolicy) Calculator {
-	 return Calculator{
-		 chKeys:    chKeys,
-		 condition: sync.NewCond(&sync.Mutex{}),
-		 dbConfig:  dbConfig,
-		 logger:    logger,
-		 workQueue: types.NewWorkQueue(),
-		 policy:    policy,
-	 }
- }
- 
- func (c *Calculator) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup) bool {
-	 db, err := NewArangoClient(c.dbConfig, c.logger)
-	 if err != nil {
-		 c.logger.Error(err.Error())
-		 return false
-	 }
- 
-	 err = db.ValidateGraph(ctx)
-	 if err != nil {
-		 c.logger.Error(err.Error())
-		 return false
-	 }
- 
-	 c.dbClient = db
-	 wg.Add(1)
-	 go func() {
-		 defer wg.Done()
- 
-		 for {
-			 // incoming keys should trigger calculation for associated data
-			 msg, ok := <-c.chKeys
-			 c.workQueue.Append(msg)
-			 if !ok {
-				 return
-			 }
-		 }
-	 }()
- 
-	 cancelled := false
-	 wg.Add(1)
-	 go func() {
-		 defer wg.Done()
-		 for !cancelled {
-			 if c.workQueue.Len() > 0 {
-				 c.condition.L.Lock()
-				 if c.workQueue.Workers.Count() >= workerMax {
-					 c.condition.Wait()
-				 }
- 
-				 c.condition.L.Unlock()
-				 key := c.workQueue.First()
-				 c.logger.Write(slog.LevelDebug, fmt.Sprintf("workers %v len %v scored %s", c.workQueue.Workers.Count(), c.workQueue.Len(), key))
-				 go c.score(ctx, key)
-			 } else {
-				 time.Sleep(250 * time.Millisecond)
-			 }
-		 }
-		 return
-	 }()
- 
-	 wg.Add(1)
-	 go func() { // Graceful shutdown
-		 defer wg.Done()
- 
-		 <-ctx.Done()
-		 cancelled = true
-		 c.logger.Write(slog.LevelInfo, "shutdown received")
-	 }()
-	 return true
- }
- 
- func (c *Calculator) score(ctx context.Context, key string) {
-	 c.workQueue.Workers.Increment()
-	 defer c.workQueue.Workers.Decrement()
- 
-	 time.Sleep(1500 * time.Millisecond)
-	 annotations, err := c.dbClient.QueryAnnotations(ctx, key)
-	 if err != nil {
-		 c.logger.Error(err.Error())
-		 return
-	 }
-	 var layer contracts.LayerType = annotations[0].Layer
-	 var docScore documents.Score
- 
-	 switch layer {
-	 case contracts.Application:
-		 // Find the score of CICD pipeline that built the app
-		 tagScore, err := c.dbClient.QueryScoreByTag(ctx, annotations[0].Tag)
-		 if err != nil {
-			 c.logger.Error(err.Error())
-			 return
-		 }
- 
-		 // Calculate the app layer confidence, linked to the CICD score
-		 docScore = documents.NewScore(key, annotations, c.policy, tagScore.Confidence)
-		 err = c.dbClient.CreateDocument(ctx, docScore.Key.String(), docScore, documents.VertexScores)
-		 if err != nil {
-			 c.logger.Error(err.Error())
-			 return
-		 }
- 
-		 // Create an edge between the score and the data
-		 err = c.dbClient.CreateEdge(ctx, docScore.Key.String(), key, documents.EdgeScoring)
-		 if err != nil {
-			 c.logger.Error(err.Error())
-			 return
-		 }
- 
-		 // Create an edge between the app score and CICD score
-		 err = c.dbClient.CreateEdge(ctx, docScore.Key.String(), tagScore.Key.String(), documents.EdgeLinkage)
-		 if err != nil {
-			 c.logger.Error(err.Error())
-			 return
-		 }
- 
-	 default:
-		 docScore = documents.NewScore(key, annotations, c.policy, 1)
-		 err = c.dbClient.CreateDocument(ctx, docScore.Key.String(), docScore, documents.VertexScores)
-		 if err != nil {
-			 c.logger.Error(err.Error())
-			 return
-		 }
-		 err = c.dbClient.CreateEdge(ctx, docScore.Key.String(), key, documents.EdgeScoring)
-		 if err != nil {
-			 c.logger.Error(err.Error())
-			 return
-		 }
-	 }
- 
-	 c.condition.Signal()
- }
- 
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"sync"
+	"time"
+
+	"github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
+	"github.com/project-alvarium/alvarium-sdk-go/pkg/interfaces"
+	"github.com/project-alvarium/scoring-apps-go/internal/calculator/types"
+	"github.com/project-alvarium/scoring-apps-go/internal/config"
+	"github.com/project-alvarium/scoring-apps-go/pkg/documents"
+	"github.com/project-alvarium/scoring-apps-go/pkg/policies"
+)
+
+type Calculator struct {
+	chKeys    chan string
+	condition *sync.Cond
+	dbClient  *ArangoClient
+	dbConfig  config.DatabaseInfo
+	logger    interfaces.Logger
+	workQueue *types.WorkQueue
+	policy    policies.DcfPolicy
+}
+
+const (
+	workerMax int = 5
+)
+
+func NewCalculator(chKeys chan string, dbConfig config.DatabaseInfo, logger interfaces.Logger, policy policies.DcfPolicy) Calculator {
+	return Calculator{
+		chKeys:    chKeys,
+		condition: sync.NewCond(&sync.Mutex{}),
+		dbConfig:  dbConfig,
+		logger:    logger,
+		workQueue: types.NewWorkQueue(),
+		policy:    policy,
+	}
+}
+
+func (c *Calculator) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup) bool {
+	db, err := NewArangoClient(c.dbConfig, c.logger)
+	if err != nil {
+		c.logger.Error(err.Error())
+		return false
+	}
+
+	err = db.ValidateGraph(ctx)
+	if err != nil {
+		c.logger.Error(err.Error())
+		return false
+	}
+
+	c.dbClient = db
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for {
+			// incoming keys should trigger calculation for associated data
+			msg, ok := <-c.chKeys
+			c.workQueue.Append(msg)
+			if !ok {
+				return
+			}
+		}
+	}()
+
+	cancelled := false
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for !cancelled {
+			if c.workQueue.Len() > 0 {
+				c.condition.L.Lock()
+				if c.workQueue.Workers.Count() >= workerMax {
+					c.condition.Wait()
+				}
+
+				c.condition.L.Unlock()
+				key := c.workQueue.First()
+				c.logger.Write(slog.LevelDebug, fmt.Sprintf("workers %v len %v scored %s", c.workQueue.Workers.Count(), c.workQueue.Len(), key))
+				go c.score(ctx, key)
+			} else {
+				time.Sleep(250 * time.Millisecond)
+			}
+		}
+		return
+	}()
+
+	wg.Add(1)
+	go func() { // Graceful shutdown
+		defer wg.Done()
+
+		<-ctx.Done()
+		cancelled = true
+		c.logger.Write(slog.LevelInfo, "shutdown received")
+	}()
+	return true
+}
+
+func (c *Calculator) score(ctx context.Context, key string) {
+	c.workQueue.Workers.Increment()
+	defer c.workQueue.Workers.Decrement()
+
+	time.Sleep(1500 * time.Millisecond)
+	annotations, err := c.dbClient.QueryAnnotations(ctx, key)
+	if err != nil {
+		c.logger.Error(err.Error())
+		return
+	}
+	var layer contracts.LayerType = annotations[0].Layer
+	var docScore documents.Score
+
+	tagScoreMap := make(map[string]documents.Score)
+	switch layer {
+	case contracts.Application:
+
+		// Find the confidence scores of CICD pipelines that built the apps that processed the piece of data
+		for _, annotation := range annotations {
+			// Check if the confidence for the tag is already computed
+			if _, exists := tagScoreMap[annotation.Tag]; !exists {
+				tagScore, err := c.dbClient.QueryScoreByTag(ctx, annotation.Tag, contracts.CiCd)
+				if err != nil {
+					c.logger.Error(err.Error())
+					return
+				}
+				tagScoreMap[annotation.Tag] = tagScore
+			}
+		}
+
+		// Calculate the app layer confidence, now linked to the map of CICD scores
+		docScore = documents.NewScore(key, annotations, c.policy, tagScoreMap)
+		err = c.dbClient.CreateDocument(ctx, docScore.Key.String(), docScore, documents.VertexScores)
+		if err != nil {
+			c.logger.Error(err.Error())
+			return
+		}
+
+		// Create an edge between the score and the data
+		err = c.dbClient.CreateEdge(ctx, docScore.Key.String(), key, documents.EdgeScoring)
+		if err != nil {
+			c.logger.Error(err.Error())
+			return
+		}
+
+		for _, tagScore := range tagScoreMap {
+			// Create an edge between the app score and CICD score
+			err = c.dbClient.CreateEdge(ctx, docScore.Key.String(), tagScore.Key.String(), documents.EdgeLinkage)
+			if err != nil {
+				c.logger.Error(err.Error())
+				return
+			}
+		}
+
+	default:
+		docScore = documents.NewScore(key, annotations, c.policy, tagScoreMap)
+		err = c.dbClient.CreateDocument(ctx, docScore.Key.String(), docScore, documents.VertexScores)
+		if err != nil {
+			c.logger.Error(err.Error())
+			return
+		}
+		err = c.dbClient.CreateEdge(ctx, docScore.Key.String(), key, documents.EdgeScoring)
+		if err != nil {
+			c.logger.Error(err.Error())
+			return
+		}
+	}
+
+	c.condition.Signal()
+}

--- a/internal/calculator/calculator.go
+++ b/internal/calculator/calculator.go
@@ -163,7 +163,7 @@ func (c *Calculator) score(ctx context.Context, key string) {
 
 		for _, tagScore := range tagScoreMap {
 			// Create an edge between the app score and CICD score
-			err = c.dbClient.CreateEdge(ctx, docScore.Key.String(), tagScore.Key.String(), documents.EdgeLinkage)
+			err = c.dbClient.CreateEdge(ctx, tagScore.Key.String(), docScore.Key.String(), documents.EdgeLinkage)
 			if err != nil {
 				c.logger.Error(err.Error())
 				return

--- a/internal/calculator/db.go
+++ b/internal/calculator/db.go
@@ -12,183 +12,226 @@
  * the License.
  *******************************************************************************/
 
-package calculator
+ package calculator
 
-import (
-	"context"
-	"fmt"
-	"log/slog"
-
-	"github.com/arangodb/go-driver"
-	"github.com/arangodb/go-driver/http"
-	"github.com/project-alvarium/alvarium-sdk-go/pkg/interfaces"
-	"github.com/project-alvarium/scoring-apps-go/internal/config"
-	"github.com/project-alvarium/scoring-apps-go/pkg/documents"
-)
-
-type ArangoClient struct {
-	cfg    config.ArangoConfig
-	client driver.Client
-	logger interfaces.Logger
-}
-
-func NewArangoClient(dbConfig config.DatabaseInfo, logger interfaces.Logger) (*ArangoClient, error) {
-	cfg, ok := dbConfig.Config.(config.ArangoConfig)
-	if !ok {
-		return nil, fmt.Errorf("invalid config type, expected %s", config.DBArango)
-	}
-	c := ArangoClient{
-		cfg:    cfg,
-		logger: logger,
-	}
-
-	conn, err := http.NewConnection(
-		http.ConnectionConfig{
-			Endpoints: []string{cfg.Provider.Uri()},
-		})
-	if err != nil {
-		return nil, err
-	}
-	client, err := driver.NewClient(
-		driver.ClientConfig{
-			Connection: conn,
-		})
-	if err != nil {
-		return nil, err
-	}
-	c.client = client
-	return &c, nil
-}
-
-func (c *ArangoClient) CreateDocument(ctx context.Context, documentKey string, document interface{}, collectionName string) error {
-	db, err := c.client.Database(ctx, c.cfg.DatabaseName)
-	if err != nil {
-		return err
-	}
-
-	graph, err := db.Graph(ctx, c.cfg.GraphName)
-	if err != nil {
-		return err
-	}
-
-	coll, err := graph.VertexCollection(ctx, collectionName) // Fetch the "data" collection
-	if err != nil {
-		return err
-	}
-
-	exists, err := coll.DocumentExists(ctx, documentKey)
-	if err != nil {
-		return err
-	}
-
-	if !exists {
-		_, err := coll.CreateDocument(ctx, document)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (c *ArangoClient) CreateEdge(ctx context.Context, src string, target string, collectionName string) error {
-	db, err := c.client.Database(ctx, c.cfg.DatabaseName)
-	if err != nil {
-		return err
-	}
-
-	graph, err := db.Graph(ctx, c.cfg.GraphName)
-	if err != nil {
-		return err
-	}
-
-	edge, _, err := graph.EdgeCollection(ctx, collectionName)
-	if err != nil {
-		return err
-	}
-
-	switch collectionName {
-	case documents.EdgeScoring:
-		doc := documents.Scoring{
-			From: fmt.Sprintf("%s/%s", documents.VertexScores, src),
-			To:   fmt.Sprintf("%s/%s", documents.VertexData, target),
-		}
-		_, err = edge.CreateDocument(ctx, doc)
-	}
-	return err
-}
-
-func (c *ArangoClient) QueryAnnotations(ctx context.Context, key string) ([]documents.Annotation, error) {
-	db, err := c.client.Database(ctx, c.cfg.DatabaseName)
-	if err != nil {
-		return nil, err
-	}
-	query := "FOR a in annotations FILTER a.dataRef == @key RETURN a"
-	bindVars := map[string]interface{}{
-		"key": key,
-	}
-	cursor, err := db.Query(ctx, query, bindVars)
-	if err != nil {
-		return nil, err
-	}
-	defer cursor.Close()
-
-	var annotations []documents.Annotation
-	for {
-		var doc documents.Annotation
-		_, err := cursor.ReadDocument(ctx, &doc)
-		if driver.IsNoMoreDocuments(err) {
-			break
-		} else if err != nil {
-			return nil, err
-		}
-		annotations = append(annotations, doc)
-	}
-	return annotations, nil
-}
-
-func (c *ArangoClient) ValidateGraph(ctx context.Context) error {
-	exists, err := c.client.DatabaseExists(ctx, c.cfg.DatabaseName)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		return fmt.Errorf("database %s should already exist", c.cfg.DatabaseName)
-	} else {
-		c.logger.Write(slog.LevelDebug, "database exists "+c.cfg.DatabaseName)
-	}
-	db, err := c.client.Database(ctx, c.cfg.DatabaseName)
-	if err != nil {
-		return err
-	}
-	exists, err = db.GraphExists(ctx, c.cfg.GraphName)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		return fmt.Errorf("graph %s should already exist", c.cfg.GraphName)
-	}
-
-	c.logger.Write(slog.LevelDebug, "validating existence of edges in graph "+c.cfg.GraphName)
-	for _, item := range c.cfg.Edges {
-		exists, err = db.CollectionExists(ctx, item.CollectionName)
-		if !exists {
-			return fmt.Errorf("edge collection %s should already exist", item.CollectionName)
-		}
-	}
-
-	c.logger.Write(slog.LevelDebug, "validating existence of vertexes in graph "+c.cfg.GraphName)
-	graph, err := db.Graph(ctx, c.cfg.GraphName)
-	if err != nil {
-		return err
-	}
-	for _, v := range c.cfg.Vertexes {
-		exists, err := graph.VertexCollectionExists(ctx, v)
-		if err != nil {
-			return err
-		}
-		if !exists {
-			return fmt.Errorf("vertext collection %s should already exist", v)
-		}
-	}
-	return nil
-}
+ import (
+	 "context"
+	 "fmt"
+	 "log/slog"
+ 
+	 "github.com/arangodb/go-driver"
+	 "github.com/arangodb/go-driver/http"
+	 "github.com/project-alvarium/alvarium-sdk-go/pkg/interfaces"
+	 "github.com/project-alvarium/scoring-apps-go/internal/config"
+	 "github.com/project-alvarium/scoring-apps-go/pkg/documents"
+ )
+ 
+ type ArangoClient struct {
+	 cfg    config.ArangoConfig
+	 client driver.Client
+	 logger interfaces.Logger
+ }
+ 
+ func NewArangoClient(dbConfig config.DatabaseInfo, logger interfaces.Logger) (*ArangoClient, error) {
+	 cfg, ok := dbConfig.Config.(config.ArangoConfig)
+	 if !ok {
+		 return nil, fmt.Errorf("invalid config type, expected %s", config.DBArango)
+	 }
+	 c := ArangoClient{
+		 cfg:    cfg,
+		 logger: logger,
+	 }
+ 
+	 conn, err := http.NewConnection(
+		 http.ConnectionConfig{
+			 Endpoints: []string{cfg.Provider.Uri()},
+		 })
+	 if err != nil {
+		 return nil, err
+	 }
+	 client, err := driver.NewClient(
+		 driver.ClientConfig{
+			 Connection: conn,
+		 })
+	 if err != nil {
+		 return nil, err
+	 }
+	 c.client = client
+	 return &c, nil
+ }
+ 
+ func (c *ArangoClient) CreateDocument(ctx context.Context, documentKey string, document interface{}, collectionName string) error {
+	 db, err := c.client.Database(ctx, c.cfg.DatabaseName)
+	 if err != nil {
+		 return err
+	 }
+ 
+	 graph, err := db.Graph(ctx, c.cfg.GraphName)
+	 if err != nil {
+		 return err
+	 }
+ 
+	 coll, err := graph.VertexCollection(ctx, collectionName) // Fetch the "data" collection
+	 if err != nil {
+		 return err
+	 }
+ 
+	 exists, err := coll.DocumentExists(ctx, documentKey)
+	 if err != nil {
+		 return err
+	 }
+ 
+	 if !exists {
+		 _, err := coll.CreateDocument(ctx, document)
+		 if err != nil {
+			 return err
+		 }
+	 }
+	 return nil
+ }
+ 
+ func (c *ArangoClient) CreateEdge(ctx context.Context, src string, target string, collectionName string) error {
+	 db, err := c.client.Database(ctx, c.cfg.DatabaseName)
+	 if err != nil {
+		 return err
+	 }
+ 
+	 graph, err := db.Graph(ctx, c.cfg.GraphName)
+	 if err != nil {
+		 return err
+	 }
+ 
+	 edge, _, err := graph.EdgeCollection(ctx, collectionName)
+	 if err != nil {
+		 return err
+	 }
+ 
+	 switch collectionName {
+	 case documents.EdgeScoring:
+		 doc := documents.Scoring{
+			 From: fmt.Sprintf("%s/%s", documents.VertexScores, src),
+			 To:   fmt.Sprintf("%s/%s", documents.VertexData, target),
+		 }
+		 _, err = edge.CreateDocument(ctx, doc)
+	 case documents.EdgeLinkage:
+		 doc := documents.Linkage{
+			 From: fmt.Sprintf("%s/%s", documents.VertexScores, src),
+			 To:   fmt.Sprintf("%s/%s", documents.VertexScores, target),
+		 }
+		 _, err = edge.CreateDocument(ctx, doc)
+	 }
+	 return err
+ }
+ 
+ func (c *ArangoClient) QueryAnnotations(ctx context.Context, key string) ([]documents.Annotation, error) {
+	 db, err := c.client.Database(ctx, c.cfg.DatabaseName)
+	 if err != nil {
+		 return nil, err
+	 }
+	 query := "FOR a in annotations FILTER a.dataRef == @key RETURN a"
+	 bindVars := map[string]interface{}{
+		 "key": key,
+	 }
+	 cursor, err := db.Query(ctx, query, bindVars)
+	 if err != nil {
+		 return nil, err
+	 }
+	 defer cursor.Close()
+ 
+	 var annotations []documents.Annotation
+	 for {
+		 var doc documents.Annotation
+		 _, err := cursor.ReadDocument(ctx, &doc)
+		 if driver.IsNoMoreDocuments(err) {
+			 break
+		 } else if err != nil {
+			 return nil, err
+		 }
+		 annotations = append(annotations, doc)
+	 }
+	 return annotations, nil
+ }
+ 
+ func (c *ArangoClient) ValidateGraph(ctx context.Context) error {
+	 exists, err := c.client.DatabaseExists(ctx, c.cfg.DatabaseName)
+	 if err != nil {
+		 return err
+	 }
+	 if !exists {
+		 return fmt.Errorf("database %s should already exist", c.cfg.DatabaseName)
+	 } else {
+		 c.logger.Write(slog.LevelDebug, "database exists "+c.cfg.DatabaseName)
+	 }
+	 db, err := c.client.Database(ctx, c.cfg.DatabaseName)
+	 if err != nil {
+		 return err
+	 }
+	 exists, err = db.GraphExists(ctx, c.cfg.GraphName)
+	 if err != nil {
+		 return err
+	 }
+	 if !exists {
+		 return fmt.Errorf("graph %s should already exist", c.cfg.GraphName)
+	 }
+ 
+	 c.logger.Write(slog.LevelDebug, "validating existence of edges in graph "+c.cfg.GraphName)
+	 for _, item := range c.cfg.Edges {
+		 exists, _ = db.CollectionExists(ctx, item.CollectionName)
+		 if !exists {
+			 return fmt.Errorf("edge collection %s should already exist", item.CollectionName)
+		 }
+	 }
+ 
+	 c.logger.Write(slog.LevelDebug, "validating existence of vertexes in graph "+c.cfg.GraphName)
+	 graph, err := db.Graph(ctx, c.cfg.GraphName)
+	 if err != nil {
+		 return err
+	 }
+	 for _, v := range c.cfg.Vertexes {
+		 exists, err := graph.VertexCollectionExists(ctx, v)
+		 if err != nil {
+			 return err
+		 }
+		 if !exists {
+			 return fmt.Errorf("vertext collection %s should already exist", v)
+		 }
+	 }
+	 return nil
+ }
+ 
+ func (c *ArangoClient) QueryScoreByTag(ctx context.Context, tag string) (documents.Score, error) {
+	 db, err := c.client.Database(ctx, c.cfg.DatabaseName)
+	 if err != nil {
+		 return documents.Score{}, err
+	 }
+ 
+	 query := "FOR s in scores FILTER s.tag == @tag AND s.confidence != null RETURN s"
+	 bindVars := map[string]interface{}{
+		 "tag": tag,
+	 }
+	 cursor, err := db.Query(ctx, query, bindVars)
+	 if err != nil {
+		 return documents.Score{}, err
+	 }
+	 defer cursor.Close()
+ 
+	 // There should only be one document returned here
+	 var score documents.Score
+	 foundScore := false
+	 for {
+		 _, err := cursor.ReadDocument(ctx, &score)
+		 if driver.IsNoMoreDocuments(err) {
+			 break
+		 } else if err != nil {
+			 return documents.Score{}, err
+		 }
+		 foundScore = true
+	 }
+ 
+	 if !foundScore {
+		 return documents.Score{}, fmt.Errorf("no document found for tag: %s", tag)
+	 }
+ 
+	 return score, nil
+ }
+ 

--- a/internal/calculator/db.go
+++ b/internal/calculator/db.go
@@ -12,226 +12,227 @@
  * the License.
  *******************************************************************************/
 
- package calculator
+package calculator
 
- import (
-	 "context"
-	 "fmt"
-	 "log/slog"
- 
-	 "github.com/arangodb/go-driver"
-	 "github.com/arangodb/go-driver/http"
-	 "github.com/project-alvarium/alvarium-sdk-go/pkg/interfaces"
-	 "github.com/project-alvarium/scoring-apps-go/internal/config"
-	 "github.com/project-alvarium/scoring-apps-go/pkg/documents"
- )
- 
- type ArangoClient struct {
-	 cfg    config.ArangoConfig
-	 client driver.Client
-	 logger interfaces.Logger
- }
- 
- func NewArangoClient(dbConfig config.DatabaseInfo, logger interfaces.Logger) (*ArangoClient, error) {
-	 cfg, ok := dbConfig.Config.(config.ArangoConfig)
-	 if !ok {
-		 return nil, fmt.Errorf("invalid config type, expected %s", config.DBArango)
-	 }
-	 c := ArangoClient{
-		 cfg:    cfg,
-		 logger: logger,
-	 }
- 
-	 conn, err := http.NewConnection(
-		 http.ConnectionConfig{
-			 Endpoints: []string{cfg.Provider.Uri()},
-		 })
-	 if err != nil {
-		 return nil, err
-	 }
-	 client, err := driver.NewClient(
-		 driver.ClientConfig{
-			 Connection: conn,
-		 })
-	 if err != nil {
-		 return nil, err
-	 }
-	 c.client = client
-	 return &c, nil
- }
- 
- func (c *ArangoClient) CreateDocument(ctx context.Context, documentKey string, document interface{}, collectionName string) error {
-	 db, err := c.client.Database(ctx, c.cfg.DatabaseName)
-	 if err != nil {
-		 return err
-	 }
- 
-	 graph, err := db.Graph(ctx, c.cfg.GraphName)
-	 if err != nil {
-		 return err
-	 }
- 
-	 coll, err := graph.VertexCollection(ctx, collectionName) // Fetch the "data" collection
-	 if err != nil {
-		 return err
-	 }
- 
-	 exists, err := coll.DocumentExists(ctx, documentKey)
-	 if err != nil {
-		 return err
-	 }
- 
-	 if !exists {
-		 _, err := coll.CreateDocument(ctx, document)
-		 if err != nil {
-			 return err
-		 }
-	 }
-	 return nil
- }
- 
- func (c *ArangoClient) CreateEdge(ctx context.Context, src string, target string, collectionName string) error {
-	 db, err := c.client.Database(ctx, c.cfg.DatabaseName)
-	 if err != nil {
-		 return err
-	 }
- 
-	 graph, err := db.Graph(ctx, c.cfg.GraphName)
-	 if err != nil {
-		 return err
-	 }
- 
-	 edge, _, err := graph.EdgeCollection(ctx, collectionName)
-	 if err != nil {
-		 return err
-	 }
- 
-	 switch collectionName {
-	 case documents.EdgeScoring:
-		 doc := documents.Scoring{
-			 From: fmt.Sprintf("%s/%s", documents.VertexScores, src),
-			 To:   fmt.Sprintf("%s/%s", documents.VertexData, target),
-		 }
-		 _, err = edge.CreateDocument(ctx, doc)
-	 case documents.EdgeLinkage:
-		 doc := documents.Linkage{
-			 From: fmt.Sprintf("%s/%s", documents.VertexScores, src),
-			 To:   fmt.Sprintf("%s/%s", documents.VertexScores, target),
-		 }
-		 _, err = edge.CreateDocument(ctx, doc)
-	 }
-	 return err
- }
- 
- func (c *ArangoClient) QueryAnnotations(ctx context.Context, key string) ([]documents.Annotation, error) {
-	 db, err := c.client.Database(ctx, c.cfg.DatabaseName)
-	 if err != nil {
-		 return nil, err
-	 }
-	 query := "FOR a in annotations FILTER a.dataRef == @key RETURN a"
-	 bindVars := map[string]interface{}{
-		 "key": key,
-	 }
-	 cursor, err := db.Query(ctx, query, bindVars)
-	 if err != nil {
-		 return nil, err
-	 }
-	 defer cursor.Close()
- 
-	 var annotations []documents.Annotation
-	 for {
-		 var doc documents.Annotation
-		 _, err := cursor.ReadDocument(ctx, &doc)
-		 if driver.IsNoMoreDocuments(err) {
-			 break
-		 } else if err != nil {
-			 return nil, err
-		 }
-		 annotations = append(annotations, doc)
-	 }
-	 return annotations, nil
- }
- 
- func (c *ArangoClient) ValidateGraph(ctx context.Context) error {
-	 exists, err := c.client.DatabaseExists(ctx, c.cfg.DatabaseName)
-	 if err != nil {
-		 return err
-	 }
-	 if !exists {
-		 return fmt.Errorf("database %s should already exist", c.cfg.DatabaseName)
-	 } else {
-		 c.logger.Write(slog.LevelDebug, "database exists "+c.cfg.DatabaseName)
-	 }
-	 db, err := c.client.Database(ctx, c.cfg.DatabaseName)
-	 if err != nil {
-		 return err
-	 }
-	 exists, err = db.GraphExists(ctx, c.cfg.GraphName)
-	 if err != nil {
-		 return err
-	 }
-	 if !exists {
-		 return fmt.Errorf("graph %s should already exist", c.cfg.GraphName)
-	 }
- 
-	 c.logger.Write(slog.LevelDebug, "validating existence of edges in graph "+c.cfg.GraphName)
-	 for _, item := range c.cfg.Edges {
-		 exists, _ = db.CollectionExists(ctx, item.CollectionName)
-		 if !exists {
-			 return fmt.Errorf("edge collection %s should already exist", item.CollectionName)
-		 }
-	 }
- 
-	 c.logger.Write(slog.LevelDebug, "validating existence of vertexes in graph "+c.cfg.GraphName)
-	 graph, err := db.Graph(ctx, c.cfg.GraphName)
-	 if err != nil {
-		 return err
-	 }
-	 for _, v := range c.cfg.Vertexes {
-		 exists, err := graph.VertexCollectionExists(ctx, v)
-		 if err != nil {
-			 return err
-		 }
-		 if !exists {
-			 return fmt.Errorf("vertext collection %s should already exist", v)
-		 }
-	 }
-	 return nil
- }
- 
- func (c *ArangoClient) QueryScoreByTag(ctx context.Context, tag string) (documents.Score, error) {
-	 db, err := c.client.Database(ctx, c.cfg.DatabaseName)
-	 if err != nil {
-		 return documents.Score{}, err
-	 }
- 
-	 query := "FOR s in scores FILTER s.tag == @tag AND s.confidence != null RETURN s"
-	 bindVars := map[string]interface{}{
-		 "tag": tag,
-	 }
-	 cursor, err := db.Query(ctx, query, bindVars)
-	 if err != nil {
-		 return documents.Score{}, err
-	 }
-	 defer cursor.Close()
- 
-	 // There should only be one document returned here
-	 var score documents.Score
-	 foundScore := false
-	 for {
-		 _, err := cursor.ReadDocument(ctx, &score)
-		 if driver.IsNoMoreDocuments(err) {
-			 break
-		 } else if err != nil {
-			 return documents.Score{}, err
-		 }
-		 foundScore = true
-	 }
- 
-	 if !foundScore {
-		 return documents.Score{}, fmt.Errorf("no document found for tag: %s", tag)
-	 }
- 
-	 return score, nil
- }
- 
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/arangodb/go-driver"
+	"github.com/arangodb/go-driver/http"
+	"github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
+	"github.com/project-alvarium/alvarium-sdk-go/pkg/interfaces"
+	"github.com/project-alvarium/scoring-apps-go/internal/config"
+	"github.com/project-alvarium/scoring-apps-go/pkg/documents"
+)
+
+type ArangoClient struct {
+	cfg    config.ArangoConfig
+	client driver.Client
+	logger interfaces.Logger
+}
+
+func NewArangoClient(dbConfig config.DatabaseInfo, logger interfaces.Logger) (*ArangoClient, error) {
+	cfg, ok := dbConfig.Config.(config.ArangoConfig)
+	if !ok {
+		return nil, fmt.Errorf("invalid config type, expected %s", config.DBArango)
+	}
+	c := ArangoClient{
+		cfg:    cfg,
+		logger: logger,
+	}
+
+	conn, err := http.NewConnection(
+		http.ConnectionConfig{
+			Endpoints: []string{cfg.Provider.Uri()},
+		})
+	if err != nil {
+		return nil, err
+	}
+	client, err := driver.NewClient(
+		driver.ClientConfig{
+			Connection: conn,
+		})
+	if err != nil {
+		return nil, err
+	}
+	c.client = client
+	return &c, nil
+}
+
+func (c *ArangoClient) CreateDocument(ctx context.Context, documentKey string, document interface{}, collectionName string) error {
+	db, err := c.client.Database(ctx, c.cfg.DatabaseName)
+	if err != nil {
+		return err
+	}
+
+	graph, err := db.Graph(ctx, c.cfg.GraphName)
+	if err != nil {
+		return err
+	}
+
+	coll, err := graph.VertexCollection(ctx, collectionName) // Fetch the "data" collection
+	if err != nil {
+		return err
+	}
+
+	exists, err := coll.DocumentExists(ctx, documentKey)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		_, err := coll.CreateDocument(ctx, document)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *ArangoClient) CreateEdge(ctx context.Context, src string, target string, collectionName string) error {
+	db, err := c.client.Database(ctx, c.cfg.DatabaseName)
+	if err != nil {
+		return err
+	}
+
+	graph, err := db.Graph(ctx, c.cfg.GraphName)
+	if err != nil {
+		return err
+	}
+
+	edge, _, err := graph.EdgeCollection(ctx, collectionName)
+	if err != nil {
+		return err
+	}
+
+	switch collectionName {
+	case documents.EdgeScoring:
+		doc := documents.Scoring{
+			From: fmt.Sprintf("%s/%s", documents.VertexScores, src),
+			To:   fmt.Sprintf("%s/%s", documents.VertexData, target),
+		}
+		_, err = edge.CreateDocument(ctx, doc)
+	case documents.EdgeLinkage:
+		doc := documents.Linkage{
+			From: fmt.Sprintf("%s/%s", documents.VertexScores, src),
+			To:   fmt.Sprintf("%s/%s", documents.VertexScores, target),
+		}
+		_, err = edge.CreateDocument(ctx, doc)
+	}
+	return err
+}
+
+func (c *ArangoClient) QueryAnnotations(ctx context.Context, key string) ([]documents.Annotation, error) {
+	db, err := c.client.Database(ctx, c.cfg.DatabaseName)
+	if err != nil {
+		return nil, err
+	}
+	query := "FOR a in annotations FILTER a.dataRef == @key RETURN a"
+	bindVars := map[string]interface{}{
+		"key": key,
+	}
+	cursor, err := db.Query(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close()
+
+	var annotations []documents.Annotation
+	for {
+		var doc documents.Annotation
+		_, err := cursor.ReadDocument(ctx, &doc)
+		if driver.IsNoMoreDocuments(err) {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+		annotations = append(annotations, doc)
+	}
+	return annotations, nil
+}
+
+func (c *ArangoClient) ValidateGraph(ctx context.Context) error {
+	exists, err := c.client.DatabaseExists(ctx, c.cfg.DatabaseName)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("database %s should already exist", c.cfg.DatabaseName)
+	} else {
+		c.logger.Write(slog.LevelDebug, "database exists "+c.cfg.DatabaseName)
+	}
+	db, err := c.client.Database(ctx, c.cfg.DatabaseName)
+	if err != nil {
+		return err
+	}
+	exists, err = db.GraphExists(ctx, c.cfg.GraphName)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("graph %s should already exist", c.cfg.GraphName)
+	}
+
+	c.logger.Write(slog.LevelDebug, "validating existence of edges in graph "+c.cfg.GraphName)
+	for _, item := range c.cfg.Edges {
+		exists, _ = db.CollectionExists(ctx, item.CollectionName)
+		if !exists {
+			return fmt.Errorf("edge collection %s should already exist", item.CollectionName)
+		}
+	}
+
+	c.logger.Write(slog.LevelDebug, "validating existence of vertexes in graph "+c.cfg.GraphName)
+	graph, err := db.Graph(ctx, c.cfg.GraphName)
+	if err != nil {
+		return err
+	}
+	for _, v := range c.cfg.Vertexes {
+		exists, err := graph.VertexCollectionExists(ctx, v)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("vertext collection %s should already exist", v)
+		}
+	}
+	return nil
+}
+
+func (c *ArangoClient) QueryScoreByTag(ctx context.Context, tag string, layer contracts.LayerType) (documents.Score, error) {
+	db, err := c.client.Database(ctx, c.cfg.DatabaseName)
+	if err != nil {
+		return documents.Score{}, err
+	}
+
+	query := "FOR s in scores FILTER s.tag == @tag AND s.layer == @layer AND s.confidence != null RETURN s"
+	bindVars := map[string]interface{}{
+		"tag":   tag,
+		"layer": layer,
+	}
+	cursor, err := db.Query(ctx, query, bindVars)
+	if err != nil {
+		return documents.Score{}, err
+	}
+	defer cursor.Close()
+
+	// There should only be one document returned here
+	var score documents.Score
+	foundScore := false
+	for {
+		_, err := cursor.ReadDocument(ctx, &score)
+		if driver.IsNoMoreDocuments(err) {
+			break
+		} else if err != nil {
+			return documents.Score{}, err
+		}
+		foundScore = true
+	}
+
+	if !foundScore {
+		return documents.Score{}, fmt.Errorf("no document found for tag: %s", tag)
+	}
+
+	return score, nil
+}

--- a/internal/calculator/db.go
+++ b/internal/calculator/db.go
@@ -206,7 +206,12 @@ func (c *ArangoClient) QueryScoreByTag(ctx context.Context, tag string, layer co
 		return documents.Score{}, err
 	}
 
-	query := "FOR s in scores FILTER s.tag == @tag AND s.layer == @layer AND s.confidence != null RETURN s"
+	query := `
+	FOR s in scores
+		FILTER @tag IN s.tag AND s.layer == @layer AND s.confidence != null
+		SORT s.timestamp DESC
+		RETURN s
+	`
 	bindVars := map[string]interface{}{
 		"tag":   tag,
 		"layer": layer,

--- a/internal/calculator/db.go
+++ b/internal/calculator/db.go
@@ -210,6 +210,7 @@ func (c *ArangoClient) QueryScoreByTag(ctx context.Context, tag string, layer co
 	FOR s in scores
 		FILTER @tag IN s.tag AND s.layer == @layer AND s.confidence != null
 		SORT s.timestamp DESC
+		LIMIT 1
 		RETURN s
 	`
 	bindVars := map[string]interface{}{

--- a/internal/calculator/db.go
+++ b/internal/calculator/db.go
@@ -114,8 +114,8 @@ func (c *ArangoClient) CreateEdge(ctx context.Context, src string, target string
 			To:   fmt.Sprintf("%s/%s", documents.VertexData, target),
 		}
 		_, err = edge.CreateDocument(ctx, doc)
-	case documents.EdgeLinkage:
-		doc := documents.Linkage{
+	case documents.EdgeStack:
+		doc := documents.Stack{
 			From: fmt.Sprintf("%s/%s", documents.VertexScores, src),
 			To:   fmt.Sprintf("%s/%s", documents.VertexScores, target),
 		}

--- a/pkg/documents/types.go
+++ b/pkg/documents/types.go
@@ -82,17 +82,26 @@ type Score struct {
 	Layer      contracts.LayerType `json:"layer,omitempty"`
 }
 
+func uniqueTags(annotations []Annotation) []string {
+	unique := make(map[string]bool)
+	var result []string
+
+	for _, annotation := range annotations {
+		if !unique[annotation.Tag] {
+			unique[annotation.Tag] = true
+			result = append(result, annotation.Tag)
+		}
+	}
+	return result
+}
+
 func NewScore(dataRef string, annotations []Annotation, policy policies.DcfPolicy, tagScores map[string]Score) Score {
 	// All incoming annotations will have the same layer value
 	layer := annotations[0].Layer
 
 	// The received annotations might have multiple tag values
 	// The score tag should contain all these tag values
-	scoreTag := make([]string, len(tagScores))
-
-	for _, annotation := range annotations {
-		scoreTag = append(scoreTag, annotation.Tag)
-	}
+	scoreTag := uniqueTags(annotations)
 
 	var totalTagConfidence float64
 	var totalWeight, passedWeight float32

--- a/pkg/documents/types.go
+++ b/pkg/documents/types.go
@@ -27,7 +27,7 @@ const (
 	EdgeLineage       string = "lineage"
 	EdgeScoring       string = "scoring"
 	EdgeTrust         string = "trust"
-	EdgeLinkage       string = "linkage"
+	EdgeStack         string = "stack"
 	VertexAnnotations string = "annotations"
 	VertexData        string = "data"
 	VertexScores      string = "scores"
@@ -153,8 +153,8 @@ type Scoring struct {
 	To   string `json:"_to"`
 }
 
-// Scoring represents a document in the "linkage" edge collection
-type Linkage struct {
+// Scoring represents a document in the "stack" edge collection
+type Stack struct {
 	From string `json:"_from"`
 	To   string `json:"_to"`
 }

--- a/pkg/documents/types.go
+++ b/pkg/documents/types.go
@@ -12,114 +12,131 @@
  * the License.
  *******************************************************************************/
 
-package documents
+ package documents
 
-import (
-	"math"
-	"time"
-
-	"github.com/oklog/ulid/v2"
-	"github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
-	"github.com/project-alvarium/scoring-apps-go/pkg/policies"
-)
-
-const (
-	EdgeLineage       string = "lineage"
-	EdgeScoring       string = "scoring"
-	EdgeTrust         string = "trust"
-	VertexAnnotations string = "annotations"
-	VertexData        string = "data"
-	VertexScores      string = "scores"
-)
-
-// Data represents a document in the "data" vertex collection
-type Data struct {
-	Key       string    `json:"_key,omitempty"`      // Key uniquely identifies the document in the database
-	Timestamp time.Time `json:"timestamp,omitempty"` // Timestamp indicates when the document was created
-}
-
-// Annotation represents a document in the "annotation" vertex collection
-type Annotation struct {
-	Key         string              `json:"_key,omitempty"`    // Key uniquely identifies the document in the database
-	DataRef     string              `json:"dataRef,omitempty"` // DataRef points to the key of the data being annotated
-	Hash        contracts.HashType  `json:"hash,omitempty"`    // Hash identifies which algorithm was used to construct the hash
-	Host        string              `json:"host,omitempty"`    // Host is the hostname of the node making the annotation
-	Tag         string              `json:"tag,omitempty"`     // Tag is the hash of the source artifact tag that emitted data being annotated
-	Layer       contracts.LayerType `json:"layer,omitempty"`
-	Kind        string              `json:"type,omitempty"`      // Kind indicates what kind of annotation this is. Defined as string to allow for annotation types outside of the Alvarium Go SDK
-	Signature   string              `json:"signature,omitempty"` // Signature contains the signature of the party making the annotation
-	IsSatisfied bool                `json:"isSatisfied"`         // IsSatisfied indicates whether the criteria defining the annotation were fulfilled
-	Timestamp   time.Time           `json:"timestamp,omitempty"` // Timestamp indicates when the annotation was created
-}
-
-// NewAnnotation will map an Alvarium SDK annotation into an Annotation document
-func NewAnnotation(a contracts.Annotation) Annotation {
-	return Annotation{
-		Key:         a.Id.String(),
-		DataRef:     a.Key,
-		Hash:        a.Hash,
-		Host:        a.Host,
-		Tag:         a.Tag,
-		Layer:       a.Layer,
-		Kind:        string(a.Kind),
-		Signature:   a.Signature,
-		IsSatisfied: a.IsSatisfied,
-		Timestamp:   a.Timestamp,
-	}
-}
-
-// Score represents a document in the "score" vertex collection
-type Score struct {
-	Key        ulid.ULID `json:"_key,omitempty"`       // Key uniquely identifies the document in the database
-	DataRef    string    `json:"dataRef,omitempty"`    // DataRef points to the key of the data being annotated
-	Passed     int       `json:"score,omitempty"`      // Passed indicates how many of the annotations for a given dataRef were Satisfied
-	Count      int       `json:"count,omitempty"`      // Count indicates the total number of annotations applicable to a dataRef
-	Policy     string    `json:"policy,omitempty"`     // Policy will indicate some version of the policy used to calculate confidence
-	Confidence float64   `json:"confidence,omitempty"` // Confidence is the percentage of trust in the dataRef
-	Timestamp  time.Time `json:"timestamp,omitempty"`  // Timestamp indicates when the score was calculated
-}
-
-func NewScore(dataRef string, annotations []Annotation, policy policies.DcfPolicy) Score {
-	var totalWeight, passedWeight float32
-	var passed int
-	for _, a := range annotations {
-		w := policy.FetchWeight(a.Kind)
-		totalWeight += float32(w.Value)
-		if a.IsSatisfied {
-			passed++
-			passedWeight += float32(w.Value)
-		}
-	}
-
-	confidence := float64(passedWeight / totalWeight)
-	confidence = math.Round(confidence*100) / 100
-
-	s := Score{
-		Key:        NewULID(),
-		DataRef:    dataRef,
-		Passed:     passed,
-		Count:      len(annotations),
-		Policy:     policy.Name,
-		Confidence: confidence,
-		Timestamp:  time.Now(),
-	}
-	return s
-}
-
-// Trust represents a document in the "trust" edge collection
-type Trust struct {
-	From string `json:"_from"`
-	To   string `json:"_to"`
-}
-
-// Lineage represents a document in the "lineage" edge collection
-type Lineage struct {
-	From string `json:"_from"`
-	To   string `json:"_to"`
-}
-
-// Scoring represents a document in the "scoring" edge collection
-type Scoring struct {
-	From string `json:"_from"`
-	To   string `json:"_to"`
-}
+ import (
+	 "math"
+	 "time"
+ 
+	 "github.com/oklog/ulid/v2"
+	 "github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
+	 "github.com/project-alvarium/scoring-apps-go/pkg/policies"
+ )
+ 
+ const (
+	 EdgeLineage       string = "lineage"
+	 EdgeScoring       string = "scoring"
+	 EdgeTrust         string = "trust"
+	 EdgeLinkage       string = "linkage"
+	 VertexAnnotations string = "annotations"
+	 VertexData        string = "data"
+	 VertexScores      string = "scores"
+ )
+ 
+ // Data represents a document in the "data" vertex collection
+ type Data struct {
+	 Key       string    `json:"_key,omitempty"`      // Key uniquely identifies the document in the database
+	 Timestamp time.Time `json:"timestamp,omitempty"` // Timestamp indicates when the document was created
+ }
+ 
+ // Annotation represents a document in the "annotation" vertex collection
+ type Annotation struct {
+	 Key         string              `json:"_key,omitempty"`    // Key uniquely identifies the document in the database
+	 DataRef     string              `json:"dataRef,omitempty"` // DataRef points to the key of the data being annotated
+	 Hash        contracts.HashType  `json:"hash,omitempty"`    // Hash identifies which algorithm was used to construct the hash
+	 Host        string              `json:"host,omitempty"`    // Host is the hostname of the node making the annotation
+	 Tag         string              `json:"tag,omitempty"`     // Tag is the hash of the source artifact tag that emitted data being annotated
+	 Layer       contracts.LayerType `json:"layer,omitempty"`
+	 Kind        string              `json:"type,omitempty"`      // Kind indicates what kind of annotation this is. Defined as string to allow for annotation types outside of the Alvarium Go SDK
+	 Signature   string              `json:"signature,omitempty"` // Signature contains the signature of the party making the annotation
+	 IsSatisfied bool                `json:"isSatisfied"`         // IsSatisfied indicates whether the criteria defining the annotation were fulfilled
+	 Timestamp   time.Time           `json:"timestamp,omitempty"` // Timestamp indicates when the annotation was created
+ }
+ 
+ // NewAnnotation will map an Alvarium SDK annotation into an Annotation document
+ func NewAnnotation(a contracts.Annotation) Annotation {
+	 return Annotation{
+		 Key:         a.Id.String(),
+		 DataRef:     a.Key,
+		 Hash:        a.Hash,
+		 Host:        a.Host,
+		 Tag:         a.Tag,
+		 Layer:       a.Layer,
+		 Kind:        string(a.Kind),
+		 Signature:   a.Signature,
+		 IsSatisfied: a.IsSatisfied,
+		 Timestamp:   a.Timestamp,
+	 }
+ }
+ 
+ // Score represents a document in the "score" vertex collection
+ type Score struct {
+	 Key        ulid.ULID `json:"_key,omitempty"`       // Key uniquely identifies the document in the database
+	 DataRef    string    `json:"dataRef,omitempty"`    // DataRef points to the key of the data being annotated
+	 Passed     int       `json:"score,omitempty"`      // Passed indicates how many of the annotations for a given dataRef were Satisfied
+	 Count      int       `json:"count,omitempty"`      // Count indicates the total number of annotations applicable to a dataRef
+	 Policy     string    `json:"policy,omitempty"`     // Policy will indicate some version of the policy used to calculate confidence
+	 Confidence float64   `json:"confidence,omitempty"` // Confidence is the percentage of trust in the dataRef
+	 Timestamp  time.Time `json:"timestamp,omitempty"`  // Timestamp indicates when the score was calculated
+	 Tag        string    `json:"tag,omitempty"`
+ }
+ 
+ func NewScore(dataRef string, annotations []Annotation, policy policies.DcfPolicy, factor float64) Score {
+	 var tag string
+	 // Only tag CICD layer scores
+	 if annotations[0].Layer == contracts.CiCd {
+		 tag = annotations[0].Tag
+	 }
+ 
+	 var totalWeight, passedWeight float32
+	 var passed int
+	 for _, a := range annotations {
+		 w := policy.FetchWeight(a.Kind)
+		 totalWeight += float32(w.Value)
+		 if a.IsSatisfied {
+			 passed++
+			 passedWeight += float32(w.Value)
+		 }
+	 }
+ 
+	 confidence := float64(passedWeight / totalWeight)
+	 confidence = math.Round(confidence*100) / 100
+	 confidence *= factor
+ 
+	 s := Score{
+		 Key:        NewULID(),
+		 DataRef:    dataRef,
+		 Passed:     passed,
+		 Count:      len(annotations),
+		 Policy:     policy.Name,
+		 Confidence: confidence,
+		 Timestamp:  time.Now(),
+		 Tag:        tag,
+	 }
+	 return s
+ }
+ 
+ // Trust represents a document in the "trust" edge collection
+ type Trust struct {
+	 From string `json:"_from"`
+	 To   string `json:"_to"`
+ }
+ 
+ // Lineage represents a document in the "lineage" edge collection
+ type Lineage struct {
+	 From string `json:"_from"`
+	 To   string `json:"_to"`
+ }
+ 
+ // Scoring represents a document in the "scoring" edge collection
+ type Scoring struct {
+	 From string `json:"_from"`
+	 To   string `json:"_to"`
+ }
+ 
+ // Scoring represents a document in the "linkage" edge collection
+ type Linkage struct {
+	 From string `json:"_from"`
+	 To   string `json:"_to"`
+ }
+ 

--- a/pkg/documents/types.go
+++ b/pkg/documents/types.go
@@ -90,10 +90,8 @@ func NewScore(dataRef string, annotations []Annotation, policy policies.DcfPolic
 	// The score tag should contain all these tag values
 	scoreTag := make([]string, len(tagScores))
 
-	i := 0
-	for k := range tagScores {
-		scoreTag[i] = k
-		i++
+	for _, annotation := range annotations {
+		scoreTag = append(scoreTag, annotation.Tag)
 	}
 
 	var totalTagConfidence float64

--- a/pkg/documents/types.go
+++ b/pkg/documents/types.go
@@ -82,26 +82,21 @@ type Score struct {
 	Layer      contracts.LayerType `json:"layer,omitempty"`
 }
 
-func uniqueTags(annotations []Annotation) []string {
-	unique := make(map[string]bool)
-	var result []string
-
-	for _, annotation := range annotations {
-		if !unique[annotation.Tag] {
-			unique[annotation.Tag] = true
-			result = append(result, annotation.Tag)
-		}
-	}
-	return result
-}
-
 func NewScore(dataRef string, annotations []Annotation, policy policies.DcfPolicy, tagScores map[string]Score) Score {
 	// All incoming annotations will have the same layer value
 	layer := annotations[0].Layer
 
 	// The received annotations might have multiple tag values
 	// The score tag should contain all these tag values
-	scoreTag := uniqueTags(annotations)
+	uniqueTags := make(map[string]bool)
+	var scoreTag []string
+
+	for _, annotation := range annotations {
+		if !uniqueTags[annotation.Tag] {
+			uniqueTags[annotation.Tag] = true
+			scoreTag = append(scoreTag, annotation.Tag)
+		}
+	}
 
 	var totalTagConfidence float64
 	var totalWeight, passedWeight float32

--- a/pkg/documents/types.go
+++ b/pkg/documents/types.go
@@ -114,7 +114,12 @@ func NewScore(dataRef string, annotations []Annotation, policy policies.DcfPolic
 			totalTagConfidence += tagScore.Confidence
 		} else {
 			// Default value that penalizes the score for not having stack confidence
-			totalTagConfidence += 0.7
+			// This happens for layers that should have stack confidence only (App, OS)
+			if layer == contracts.Application || layer == contracts.Os {
+				totalTagConfidence += 0.7
+			} else {
+				totalTagConfidence += 1.0
+			}
 		}
 	}
 

--- a/pkg/documents/types.go
+++ b/pkg/documents/types.go
@@ -12,131 +12,143 @@
  * the License.
  *******************************************************************************/
 
- package documents
+package documents
 
- import (
-	 "math"
-	 "time"
- 
-	 "github.com/oklog/ulid/v2"
-	 "github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
-	 "github.com/project-alvarium/scoring-apps-go/pkg/policies"
- )
- 
- const (
-	 EdgeLineage       string = "lineage"
-	 EdgeScoring       string = "scoring"
-	 EdgeTrust         string = "trust"
-	 EdgeLinkage       string = "linkage"
-	 VertexAnnotations string = "annotations"
-	 VertexData        string = "data"
-	 VertexScores      string = "scores"
- )
- 
- // Data represents a document in the "data" vertex collection
- type Data struct {
-	 Key       string    `json:"_key,omitempty"`      // Key uniquely identifies the document in the database
-	 Timestamp time.Time `json:"timestamp,omitempty"` // Timestamp indicates when the document was created
- }
- 
- // Annotation represents a document in the "annotation" vertex collection
- type Annotation struct {
-	 Key         string              `json:"_key,omitempty"`    // Key uniquely identifies the document in the database
-	 DataRef     string              `json:"dataRef,omitempty"` // DataRef points to the key of the data being annotated
-	 Hash        contracts.HashType  `json:"hash,omitempty"`    // Hash identifies which algorithm was used to construct the hash
-	 Host        string              `json:"host,omitempty"`    // Host is the hostname of the node making the annotation
-	 Tag         string              `json:"tag,omitempty"`     // Tag is the hash of the source artifact tag that emitted data being annotated
-	 Layer       contracts.LayerType `json:"layer,omitempty"`
-	 Kind        string              `json:"type,omitempty"`      // Kind indicates what kind of annotation this is. Defined as string to allow for annotation types outside of the Alvarium Go SDK
-	 Signature   string              `json:"signature,omitempty"` // Signature contains the signature of the party making the annotation
-	 IsSatisfied bool                `json:"isSatisfied"`         // IsSatisfied indicates whether the criteria defining the annotation were fulfilled
-	 Timestamp   time.Time           `json:"timestamp,omitempty"` // Timestamp indicates when the annotation was created
- }
- 
- // NewAnnotation will map an Alvarium SDK annotation into an Annotation document
- func NewAnnotation(a contracts.Annotation) Annotation {
-	 return Annotation{
-		 Key:         a.Id.String(),
-		 DataRef:     a.Key,
-		 Hash:        a.Hash,
-		 Host:        a.Host,
-		 Tag:         a.Tag,
-		 Layer:       a.Layer,
-		 Kind:        string(a.Kind),
-		 Signature:   a.Signature,
-		 IsSatisfied: a.IsSatisfied,
-		 Timestamp:   a.Timestamp,
-	 }
- }
- 
- // Score represents a document in the "score" vertex collection
- type Score struct {
-	 Key        ulid.ULID `json:"_key,omitempty"`       // Key uniquely identifies the document in the database
-	 DataRef    string    `json:"dataRef,omitempty"`    // DataRef points to the key of the data being annotated
-	 Passed     int       `json:"score,omitempty"`      // Passed indicates how many of the annotations for a given dataRef were Satisfied
-	 Count      int       `json:"count,omitempty"`      // Count indicates the total number of annotations applicable to a dataRef
-	 Policy     string    `json:"policy,omitempty"`     // Policy will indicate some version of the policy used to calculate confidence
-	 Confidence float64   `json:"confidence,omitempty"` // Confidence is the percentage of trust in the dataRef
-	 Timestamp  time.Time `json:"timestamp,omitempty"`  // Timestamp indicates when the score was calculated
-	 Tag        string    `json:"tag,omitempty"`
- }
- 
- func NewScore(dataRef string, annotations []Annotation, policy policies.DcfPolicy, factor float64) Score {
-	 var tag string
-	 // Only tag CICD layer scores
-	 if annotations[0].Layer == contracts.CiCd {
-		 tag = annotations[0].Tag
-	 }
- 
-	 var totalWeight, passedWeight float32
-	 var passed int
-	 for _, a := range annotations {
-		 w := policy.FetchWeight(a.Kind)
-		 totalWeight += float32(w.Value)
-		 if a.IsSatisfied {
-			 passed++
-			 passedWeight += float32(w.Value)
-		 }
-	 }
- 
-	 confidence := float64(passedWeight / totalWeight)
-	 confidence = math.Round(confidence*100) / 100
-	 confidence *= factor
- 
-	 s := Score{
-		 Key:        NewULID(),
-		 DataRef:    dataRef,
-		 Passed:     passed,
-		 Count:      len(annotations),
-		 Policy:     policy.Name,
-		 Confidence: confidence,
-		 Timestamp:  time.Now(),
-		 Tag:        tag,
-	 }
-	 return s
- }
- 
- // Trust represents a document in the "trust" edge collection
- type Trust struct {
-	 From string `json:"_from"`
-	 To   string `json:"_to"`
- }
- 
- // Lineage represents a document in the "lineage" edge collection
- type Lineage struct {
-	 From string `json:"_from"`
-	 To   string `json:"_to"`
- }
- 
- // Scoring represents a document in the "scoring" edge collection
- type Scoring struct {
-	 From string `json:"_from"`
-	 To   string `json:"_to"`
- }
- 
- // Scoring represents a document in the "linkage" edge collection
- type Linkage struct {
-	 From string `json:"_from"`
-	 To   string `json:"_to"`
- }
- 
+import (
+	"math"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/project-alvarium/alvarium-sdk-go/pkg/contracts"
+	"github.com/project-alvarium/scoring-apps-go/pkg/policies"
+)
+
+const (
+	EdgeLineage       string = "lineage"
+	EdgeScoring       string = "scoring"
+	EdgeTrust         string = "trust"
+	EdgeLinkage       string = "linkage"
+	VertexAnnotations string = "annotations"
+	VertexData        string = "data"
+	VertexScores      string = "scores"
+)
+
+// Data represents a document in the "data" vertex collection
+type Data struct {
+	Key       string    `json:"_key,omitempty"`      // Key uniquely identifies the document in the database
+	Timestamp time.Time `json:"timestamp,omitempty"` // Timestamp indicates when the document was created
+}
+
+// Annotation represents a document in the "annotation" vertex collection
+type Annotation struct {
+	Key         string              `json:"_key,omitempty"`    // Key uniquely identifies the document in the database
+	DataRef     string              `json:"dataRef,omitempty"` // DataRef points to the key of the data being annotated
+	Hash        contracts.HashType  `json:"hash,omitempty"`    // Hash identifies which algorithm was used to construct the hash
+	Host        string              `json:"host,omitempty"`    // Host is the hostname of the node making the annotation
+	Tag         string              `json:"tag,omitempty"`     // Tag is the hash of the source artifact tag that emitted data being annotated
+	Layer       contracts.LayerType `json:"layer,omitempty"`
+	Kind        string              `json:"type,omitempty"`      // Kind indicates what kind of annotation this is. Defined as string to allow for annotation types outside of the Alvarium Go SDK
+	Signature   string              `json:"signature,omitempty"` // Signature contains the signature of the party making the annotation
+	IsSatisfied bool                `json:"isSatisfied"`         // IsSatisfied indicates whether the criteria defining the annotation were fulfilled
+	Timestamp   time.Time           `json:"timestamp,omitempty"` // Timestamp indicates when the annotation was created
+}
+
+// NewAnnotation will map an Alvarium SDK annotation into an Annotation document
+func NewAnnotation(a contracts.Annotation) Annotation {
+	return Annotation{
+		Key:         a.Id.String(),
+		DataRef:     a.Key,
+		Hash:        a.Hash,
+		Host:        a.Host,
+		Tag:         a.Tag,
+		Layer:       a.Layer,
+		Kind:        string(a.Kind),
+		Signature:   a.Signature,
+		IsSatisfied: a.IsSatisfied,
+		Timestamp:   a.Timestamp,
+	}
+}
+
+// Score represents a document in the "score" vertex collection
+type Score struct {
+	Key        ulid.ULID           `json:"_key,omitempty"`       // Key uniquely identifies the document in the database
+	DataRef    string              `json:"dataRef,omitempty"`    // DataRef points to the key of the data being annotated
+	Passed     int                 `json:"score,omitempty"`      // Passed indicates how many of the annotations for a given dataRef were Satisfied
+	Count      int                 `json:"count,omitempty"`      // Count indicates the total number of annotations applicable to a dataRef
+	Policy     string              `json:"policy,omitempty"`     // Policy will indicate some version of the policy used to calculate confidence
+	Confidence float64             `json:"confidence,omitempty"` // Confidence is the percentage of trust in the dataRef
+	Timestamp  time.Time           `json:"timestamp,omitempty"`  // Timestamp indicates when the score was calculated
+	Tag        string              `json:"tag,omitempty"`
+	Layer      contracts.LayerType `json:"layer,omitempty"`
+}
+
+func NewScore(dataRef string, annotations []Annotation, policy policies.DcfPolicy, tagScores map[string]Score) Score {
+	layer := annotations[0].Layer
+
+	var totalTagConfidence float64
+	var totalWeight, passedWeight float32
+	var passed int
+	for _, a := range annotations {
+		w := policy.FetchWeight(a.Kind)
+		totalWeight += float32(w.Value)
+		if a.IsSatisfied {
+			passed++
+			passedWeight += float32(w.Value)
+		}
+
+		tagScore, exists := tagScores[a.Tag]
+		if exists {
+			totalTagConfidence += tagScore.Confidence
+		} else {
+			// Default value that penalizes the score for not having stack confidence
+			totalTagConfidence += 0.7
+		}
+	}
+
+	averageTagConfidence := totalTagConfidence / float64(len(annotations))
+	confidence := float64(passedWeight / totalWeight)
+	confidence *= averageTagConfidence
+	confidence = math.Round(confidence*100) / 100
+
+	scoreTag := ""
+	if len(tagScores) <= 1 {
+		scoreTag = annotations[0].Tag
+	}
+
+	s := Score{
+		Key:        NewULID(),
+		DataRef:    dataRef,
+		Passed:     passed,
+		Count:      len(annotations),
+		Policy:     policy.Name,
+		Confidence: confidence,
+		Timestamp:  time.Now(),
+		Layer:      layer,
+		Tag:        scoreTag,
+	}
+	return s
+}
+
+// Trust represents a document in the "trust" edge collection
+type Trust struct {
+	From string `json:"_from"`
+	To   string `json:"_to"`
+}
+
+// Lineage represents a document in the "lineage" edge collection
+type Lineage struct {
+	From string `json:"_from"`
+	To   string `json:"_to"`
+}
+
+// Scoring represents a document in the "scoring" edge collection
+type Scoring struct {
+	From string `json:"_from"`
+	To   string `json:"_to"`
+}
+
+// Scoring represents a document in the "linkage" edge collection
+type Linkage struct {
+	From string `json:"_from"`
+	To   string `json:"_to"`
+}


### PR DESCRIPTION
Fix #13 
- Updated the score tag field to be an array of strings instead of a string.
- Updated the scoring method to use CICD layer score when scoring application layer annotations.
- Introduced new "stack" edge between App layer scores and CICD layer scores.